### PR TITLE
assumed even number of fields (not true in Web2Py 2.9.4)

### DIFF
--- a/views/plugin_cs_monitor/task_details.html
+++ b/views/plugin_cs_monitor/task_details.html
@@ -23,14 +23,18 @@
         {{else:}}
             <td>{{=task[k]}}</td>
         {{pass}}
-        {{k=fields.pop(0)}}
-        <td><b>{{=st[k].label}}</b></td>
-        {{if k == 'status':}}
-            <td>{{=task['status_']}}</td>
+        {{if len(fields)>0:}}
+            {{k=fields.pop(0)}}
+            <td><b>{{=st[k].label}}</b></td>
+            {{if k == 'status':}}
+                <td>{{=task['status_']}}</td>
+            {{else:}}
+                <td>{{=task[k]}}</td>
+            {{pass}}
         {{else:}}
-            <td>{{=task[k]}}</td>
+            <td></td><td></td>
         {{pass}}
-        <tr>
+        </tr>
     {{pass}}
     </tbody>
 </table>


### PR DESCRIPTION
Discoved small bug. The original code assumes an even number of field (to display in two columns). This causes an 'pop from empty list'.

Thanks for making the scheduler monitor, is great help.   
