### PR TITLE
Fix type error when stop a task

### DIFF
--- a/controllers/plugin_cs_monitor.py
+++ b/controllers/plugin_cs_monitor.py
@@ -286,7 +286,7 @@ def edit_task():
         session.flash = 'Task deleted correctly'
         redirect(URL('index'))
     elif request.args(1) == 'stop':
-        rtn = s.stop_task(task.id)
+        rtn = s.stop_task(task_id)
         if rtn == 1:
             session.flash = 'Task stopped'
         else:


### PR DESCRIPTION
With postgres as backend, I got this ticket

```
Traceback (most recent call last):
  File "/home/www-data/web2py/gluon/restricted.py", line 220, in restricted
    exec ccode in environment
  File "/home/www-data/web2py.git/applications/vtraffic/controllers/plugin_cs_monitor.py", line 631, in <module>
  File "/home/www-data/web2py/gluon/globals.py", line 385, in <lambda>
    self._caller = lambda f: f()
  File "/home/www-data/web2py/gluon/tools.py", line 3287, in f
    return action(*a, **b)
  File "/home/www-data/web2py.git/applications/vtraffic/controllers/plugin_cs_monitor.py", line 288, in edit_task
    rtn = s.stop_task(task.id)
  File "/home/www-data/web2py/gluon/scheduler.py", line 1069, in stop_task
    "You can retrieve results only by id or uuid")
SyntaxError: You can retrieve results only by id or uuid
```

This PR fixes the issue.
Moreover, is there a way to restart a task after it has been stopped ?
